### PR TITLE
이메일 인증 과정 수정

### DIFF
--- a/backend-api/src/main/java/com/bside/backendapi/domain/member/api/MemberController.java
+++ b/backend-api/src/main/java/com/bside/backendapi/domain/member/api/MemberController.java
@@ -78,7 +78,7 @@ public class MemberController {
     }
 
     @Operation(summary = "새 비밀번호 변경",
-            description = "인증코드 발송 시 사용된 메일(mail)과 새 비밀번호(newPassword), 비밀번호 확인(confirmPassword)를 통해로 새 비밀번호로 변경합니다.")
+            description = "인증코드 발송 시 사용된 메일(mail)과 새 비밀번호(newPassword), 비밀번호 확인(confirmPassword)를 통해 새 비밀번호로 변경합니다.")
     @PatchMapping("/public/updatePassword")
     public ResponseEntity<String> updatePassword(@Valid @RequestBody MemberUpdatePasswordRequest memberUpdatePasswordRequest) {
         if (!memberUpdatePasswordRequest.getNewPassword().equals(memberUpdatePasswordRequest.getConfirmPassword()))

--- a/backend-api/src/main/java/com/bside/backendapi/domain/member/application/MemberService.java
+++ b/backend-api/src/main/java/com/bside/backendapi/domain/member/application/MemberService.java
@@ -6,10 +6,7 @@ import com.bside.backendapi.domain.member.domain.vo.Email;
 import com.bside.backendapi.domain.member.domain.vo.LoginId;
 import com.bside.backendapi.domain.member.domain.vo.Nickname;
 import com.bside.backendapi.domain.member.dto.MemberResponse;
-import com.bside.backendapi.domain.member.error.DuplicatedEmailException;
-import com.bside.backendapi.domain.member.error.DuplicatedLoginIdException;
-import com.bside.backendapi.domain.member.error.DuplicatedNicknameException;
-import com.bside.backendapi.domain.member.error.MemberNotFoundException;
+import com.bside.backendapi.domain.member.error.*;
 import com.bside.backendapi.global.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,9 +49,15 @@ public class MemberService {
                 .delete();
     }
 
-    private void existedEmail(final Email email) {
+    public void existedEmail(final Email email) {
         if (memberRepository.existsByEmail(email)) {
             throw new DuplicatedEmailException(ErrorCode.DUPLICATED_EMAIL);
+        }
+    }
+
+    public void mailNotFound(final Email email) {
+        if (!memberRepository.existsByEmail(email)) {
+            throw new EmailNotFoundException(ErrorCode.EMAIL_NOT_FOUND);
         }
     }
 

--- a/backend-api/src/main/java/com/bside/backendapi/domain/member/error/EmailNotFoundException.java
+++ b/backend-api/src/main/java/com/bside/backendapi/domain/member/error/EmailNotFoundException.java
@@ -1,0 +1,11 @@
+package com.bside.backendapi.domain.member.error;
+
+import com.bside.backendapi.global.error.exception.BusinessException;
+import com.bside.backendapi.global.error.exception.ErrorCode;
+
+public class EmailNotFoundException extends BusinessException {
+
+    public EmailNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend-api/src/main/java/com/bside/backendapi/global/error/exception/ErrorCode.java
+++ b/backend-api/src/main/java/com/bside/backendapi/global/error/exception/ErrorCode.java
@@ -12,11 +12,12 @@ public enum ErrorCode {
     // Member
     PASSWORD_NULL_ERROR(400, "M001", "비밀번호가 입력되지 않았습니다."),
     USER_NOT_FOUND(400, "M002", "회원이 아닙니다."),
-    DUPLICATED_LOGINID(400, "M003", "중복된 아이디 입니다."),
-    DUPLICATED_EMAIL(400, "M004", "중복된 이메일 입니다."),
-    DUPLICATED_NICKNAME(400, "M005", "중복된 닉네임 입니다."),
+    DUPLICATED_LOGINID(400, "M003", "이미 존재하는 아이디 입니다."),
+    DUPLICATED_EMAIL(400, "M004", "이미 존재하는 이메일 입니다."),
+    DUPLICATED_NICKNAME(400, "M005", "이미 존재하는 닉네임 입니다."),
     DUPLICATED_PASSWORD(400, "M006", "기존 비밀번호와 동일합니다."),
     DISMATCH_PASSWORD(400, "M007", "비밀번호가 일치하지 않습니다."),
+    EMAIL_NOT_FOUND(400, "M008", "이메일이 존재하지 않습니다."),
 
     // JWT
     TOKEN_NOT_FOUND(400, "J001", "잘못된 토큰입니다."),

--- a/backend-api/src/main/java/com/bside/backendapi/global/mail/MailController.java
+++ b/backend-api/src/main/java/com/bside/backendapi/global/mail/MailController.java
@@ -1,5 +1,7 @@
 package com.bside.backendapi.global.mail;
 
+import com.bside.backendapi.domain.member.application.MemberService;
+import com.bside.backendapi.domain.member.domain.vo.Email;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
@@ -21,12 +23,32 @@ import org.springframework.web.bind.annotation.RestController;
 public class MailController {
 
     private final MailService mailService;
+    private final MemberService memberService;
 
-    @Operation(summary = "메일을 통해 인증코드 전송", description = "사용자가 입력한 메일(mail)을 통해 인증코드를 전송합니다.")
-    @PostMapping("/mail/verification-request")
-    public ResponseEntity<String> sendMail(@Valid @RequestBody VerificationRequest verificationRequest) throws MessagingException {
+    @Operation(summary = "회원가입 시, 메일을 통해 인증코드 전송",
+            description = "사용자가 입력한 메일(mail)을 통해 인증코드를 전송합니다. 메일이 이미 존재할 경우, 400 에러 반환합니다.")
+    @PostMapping("/mail/signUp")
+    public ResponseEntity<String> mailForSignUp(@Valid @RequestBody VerificationRequest verificationRequest) throws MessagingException {
+        memberService.existedEmail(Email.from(verificationRequest.getMail()));
+
         String authCode = mailService.sendMail(verificationRequest.getMail());
-        return ResponseEntity.ok().body("인증코드가 발송되었습니다. " + authCode);
+
+        log.info("인증번호 : {}", authCode);
+
+        return ResponseEntity.ok().body("인증코드가 발송되었습니다.");
+    }
+
+    @Operation(summary = "아이디 / 비밀번호 찾기 시, 메일을 통해 인증코드 전송",
+            description = "사용자가 입력한 메일(mail)을 통해 인증코드를 전송합니다. 메일이 존재하지 않을 경우, 400 에러 반환합니다.")
+    @PostMapping("/mail/recovery")
+    public ResponseEntity<String> mailForRecovery(@Valid @RequestBody VerificationRequest verificationRequest) throws MessagingException {
+        memberService.mailNotFound(Email.from(verificationRequest.getMail()));
+
+        String authCode = mailService.sendMail(verificationRequest.getMail());
+
+        log.info("인증번호 : {}", authCode);
+
+        return ResponseEntity.ok().body("인증코드가 발송되었습니다.");
     }
 
     @Operation(summary = "인증코드 검증", description = "사용자가 입력했던 메일(mail)과 인증코드(authCode)를 통해 인증코드를 검증합니다.")


### PR DESCRIPTION
- 회원가입용 메일 인증 → 이미 존재하는 메일이면 400 에러 - url 변경 : `/api/v1/public/mail/signUp`
- 아이디, 비밀번호 찾기용 메일 인증 → 존재하지 않는 메일이면 400 에러 - url 변경 : `/api/v1/public/mail/recovery`